### PR TITLE
feature (CRC-765): add ipfs/filebase cleanup service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "bs58": "^6.0.0",
         "connect-timeout": "^1.9.0",
         "cors": "^2.8.5",
+        "cron": "^4.1.4",
         "dotenv": "^16.4.7",
         "express": "5.0.0",
         "isomorphic-dompurify": "^2.20.0",
         "kubo-rpc-client": "^5.0.2",
         "lru-cache": "^11.0.0",
         "multihashes": "^4.0.3",
+        "node-cron": "^3.0.3",
         "sharp": "^0.33.4",
         "sqlstring": "^2.3.3",
         "uuid": "^11.0.5",
@@ -37,6 +39,7 @@
         "@types/connect-timeout": "^0.0.39",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/node-cron": "^3.0.11",
         "typescript": "^5.5.3"
       },
       "engines": {
@@ -1097,6 +1100,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1112,6 +1121,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.15",
@@ -1813,6 +1829,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cron": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.1.4.tgz",
+      "integrity": "sha512-PpAGyOyWZuGT3I50iGKeyZzNsDn/hp2AzRGUzXIlmnwC+bHZFTs1itnQKx171FeocEej+zTYV2JIgQM8M46LaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/cssstyle": {
@@ -3318,6 +3347,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3541,6 +3579,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/nwsapi": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/connect-timeout": "^0.0.39",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/node-cron": "^3.0.11",
     "typescript": "^5.5.3"
   },
   "engines": {
@@ -32,12 +33,14 @@
     "bs58": "^6.0.0",
     "connect-timeout": "^1.9.0",
     "cors": "^2.8.5",
+    "cron": "^4.1.4",
     "dotenv": "^16.4.7",
     "express": "5.0.0",
     "isomorphic-dompurify": "^2.20.0",
     "kubo-rpc-client": "^5.0.2",
     "lru-cache": "^11.0.0",
     "multihashes": "^4.0.3",
+    "node-cron": "^3.0.3",
     "sharp": "^0.33.4",
     "sqlstring": "^2.3.3",
     "uuid": "^11.0.5",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -31,6 +31,9 @@ const config = {
   maxAddressesSearchSize: parseInt(process.env.MAX_ADDRESSES_SEARCH_SIZE || '1000'),
   defaultAddressesSearchLimit: parseInt(process.env.DEFAULT_ADDRESSES_SEARCH_LIMIT || '50'),
   maxProfileSize: 0,
+  isCleanupEnabled: process.env.CLEANUP_ENABLED === 'true',
+  cleanupBatchSize: parseInt(process.env.CLEANUP_BATCH_SIZE || '100'),
+  cleanupInterval: parseInt(process.env.CLEANUP_INTERVAL || '30'),
 };
 
 config.maxProfileSize = config.descriptionLength + config.imageUrlLength + config.maxNameLength + config.maxImageSizeKB * 1024;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {sanitizeSearchParams} from './utils/sanitizer';
 import {PinningService} from "./services/pinningService";
 import {ProfileValidator} from "./services/profileValidator";
 import {PersistenceService} from "./services/persistenceService";
+import {CleanupService} from "./services/cleanupService";
 import { Profile, IPFSDataProfile, CompleteProfile } from './types';
 
 const app = express();
@@ -25,9 +26,11 @@ app.use(errorHandler);
 const persistenceService: PersistenceService = config.useS3 ? new PinningService() : new KuboService();
 let profileRepo: ProfileRepository = new ProfileRepository();
 let indexerService = new IndexerService(persistenceService, profileRepo);
+let cleanupService = new CleanupService(persistenceService, profileRepo);
 
 (async () => {
-  await indexerService.initialize();
+  //await indexerService.initialize();
+  await cleanupService.initialize();
 })();
 
 const haltOnTimedout = (req: Request, res: Response, next: () => void) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,10 @@ let indexerService = new IndexerService(persistenceService, profileRepo);
 let cleanupService = new CleanupService(persistenceService, profileRepo);
 
 (async () => {
-  //await indexerService.initialize();
-  await cleanupService.initialize();
+  await indexerService.initialize();
+
+  if(config.isCleanupEnabled)
+    await cleanupService.initialize();
 })();
 
 const haltOnTimedout = (req: Request, res: Response, next: () => void) => {

--- a/src/repositories/profileRepo.ts
+++ b/src/repositories/profileRepo.ts
@@ -4,6 +4,10 @@ import config from '../config/config';
 import { Profile } from '../types';
 
 export class ProfileRepository {
+  // Common column selection for all queries
+  private readonly PROFILE_COLUMNS = 'p.address, p.name, p.description, p.CID, p.lastUpdatedAt, p.registeredName, p.location, p.longitude, p.latitude';
+
+  // Prepared statements
   private insertOrUpdateProfileStmt = db.prepare(`
       INSERT INTO profiles (address, CID, lastUpdatedAt, name, description, registeredName, location, longitude, latitude)
       VALUES (@address, @CID, @lastUpdatedAt, @name, @description, @registeredName, @location, @longitude, @latitude)
@@ -39,30 +43,45 @@ export class ProfileRepository {
       DELETE FROM profiles WHERE lastUpdatedAt >= ?;
   `);
 
+  // Helper methods for data transformation
+  private convertToDbProfile(profile: Profile): any {
+    return {
+      ...profile,
+      longitude: profile.geoLocation ? profile.geoLocation[0] : null,
+      latitude: profile.geoLocation ? profile.geoLocation[1] : null
+    };
+  }
+
+  private mapRowToProfile(row: any): Profile {
+    const profile: Profile = {
+      address: row.address,
+      CID: row.CID,
+      lastUpdatedAt: row.lastUpdatedAt,
+      name: row.name,
+      description: row.description,
+      registeredName: row.registeredName,
+      location: row.location
+    };
+    
+    // Add geoLocation only if both longitude and latitude exist
+    if (row.longitude !== null && row.latitude !== null) {
+      profile.geoLocation = [row.longitude, row.latitude];
+    }
+    
+    return profile;
+  }
+
+  // Repository methods
   getLastProcessedBlock(): number {
     return this.getLastProcessedBlockStmt.get()?.lastProcessed || 0;
   }
 
   upsertProfile(profile: Profile): void {
-    // Create a database-ready object with longitude and latitude as separate columns
-    const dbProfile = {
-      ...profile,
-      longitude: profile.geoLocation ? profile.geoLocation[0] : null,
-      latitude: profile.geoLocation ? profile.geoLocation[1] : null
-    };
-
-    this.insertOrUpdateProfileStmt.run(dbProfile);
+    this.insertOrUpdateProfileStmt.run(this.convertToDbProfile(profile));
   }
 
   updateProfile(profile: Profile): void {
-    // Create a database-ready object with longitude and latitude as separate columns
-    const dbProfile = {
-      ...profile,
-      longitude: profile.geoLocation ? profile.geoLocation[0] : null,
-      latitude: profile.geoLocation ? profile.geoLocation[1] : null
-    };
-
-    this.updateProfileStmt.run(dbProfile);
+    this.updateProfileStmt.run(this.convertToDbProfile(profile));
   }
 
   deleteDataOlderThanBlock(blockNumber: number): void {
@@ -75,35 +94,39 @@ export class ProfileRepository {
     const placeholders = addresses.map(() => '?').join(',');
     
     const sql = `
-      SELECT 
-        p.address, p.name, p.description, p.CID, p.lastUpdatedAt, p.registeredName, p.location, p.longitude, p.latitude
+      SELECT ${this.PROFILE_COLUMNS}
       FROM profiles p
       WHERE p.address IN (${placeholders})
       LIMIT ?
     `;
     
     const results = db.prepare(sql).all([...addresses, config.maxListSize]);
-    
-    // Convert DB results to Profile objects with geoLocation array
-    return results.map((row: any) => {
-      const profile: Profile = {
-        address: row.address,
-        CID: row.CID,
-        lastUpdatedAt: row.lastUpdatedAt,
-        name: row.name,
-        description: row.description,
-        registeredName: row.registeredName,
-        location: row.location
-      };
-      
-      // Add geoLocation only if both longitude and latitude exist
-      if (row.longitude !== null && row.latitude !== null) {
-        profile.geoLocation = [row.longitude, row.latitude];
-      }
-      
-      return profile;
-    });
+    return results.map(this.mapRowToProfile);
   }
+
+  checkProfilesCidsExist(cids: string[]): boolean[] {
+    if (!cids.length) return [];
+
+    const placeholders = cids.map(cid => `('${cid}')`).join(',');
+    
+    const sql = `
+    WITH input_cids(cid) AS (
+        VALUES
+            ${placeholders}
+    )
+    SELECT
+        CAST(profiles.cid IS NOT NULL AS INTEGER) AS cidExists
+    FROM
+        input_cids
+    LEFT JOIN
+        profiles ON input_cids.cid = profiles.cid
+    LIMIT ?
+    `;
+
+    const results: any[] = db.prepare(sql).all([config.maxListSize]);
+
+    return results.map(result => !!result.cidExists);
+}
 
   /**
    * searchProfiles:
@@ -118,80 +141,49 @@ export class ProfileRepository {
     CID?: string;
     registeredName?: string;
     location?: string;
-  }): any[] {
-    // If no FTS filters are given, run a simpler query directly on `profiles`.
+  }): Profile[] {
     const hasFts = !!(filters.name || filters.description || filters.location);
+    const conditions: string[] = [];
+    const params: any[] = [];
 
+    // Build common filter conditions
+    if (filters.address) {
+      conditions.push('p.address LIKE ?');
+      params.push(`${filters.address}%`);
+    }
+    if (filters.CID) {
+      conditions.push('p.CID = ?');
+      params.push(filters.CID);
+    }
+    if (filters.registeredName) {
+      conditions.push('p.registeredName = ?');
+      params.push(filters.registeredName);
+    }
+
+    let sql;
+    
     if (!hasFts) {
       // -- CASE 1: No FTS-based filtering --
-      let sql = `
-        SELECT
-          p.address, p.name, p.description, p.CID, p.lastUpdatedAt, p.registeredName, p.location, p.longitude, p.latitude
+      sql = `
+        SELECT ${this.PROFILE_COLUMNS}
         FROM profiles p
       `;
-
-      const conditions: string[] = [];
-      const params: any[] = [];
-
-      if (filters.address) {
-        conditions.push('p.address LIKE ?');
-        params.push(`${filters.address}%`);
-      }
-      if (filters.CID) {
-        conditions.push('p.CID = ?');
-        params.push(filters.CID);
-      }
-      if (filters.registeredName) {
-        conditions.push('p.registeredName = ?');
-        params.push(filters.registeredName);
-      }
 
       if (conditions.length > 0) {
         sql += ' WHERE ' + conditions.join(' AND ');
       }
-
-      // Add a limit placeholder (better-sqlite3 supports LIMIT ?)
-      sql += ' LIMIT ?';
-      params.push(config.maxListSize);
-
-      const results = db.prepare(sql).all(params);
-      
-      // Convert DB results to Profile objects with geoLocation array
-      return results.map((row: any) => {
-        const profile: Profile = {
-          address: row.address,
-          CID: row.CID,
-          lastUpdatedAt: row.lastUpdatedAt,
-          name: row.name,
-          description: row.description,
-          registeredName: row.registeredName,
-          location: row.location
-        };
-        
-        // Add geoLocation only if both longitude and latitude exist
-        if (row.longitude !== null && row.latitude !== null) {
-          profile.geoLocation = [row.longitude, row.latitude];
-        }
-        
-        return profile;
-      });
     } else {
-      // -- CASE 2: At least one FTS filter (name or description) --
-      let sql = `
-        SELECT
-          p.address, p.name, p.description, p.CID, p.lastUpdatedAt, p.registeredName, p.location, p.longitude, p.latitude
+      // -- CASE 2: At least one FTS filter (name, description, or location) --
+      sql = `
+        SELECT ${this.PROFILE_COLUMNS}
         FROM profiles_fts f
         JOIN profiles p ON p.rowid = f.rowid
         WHERE
       `;
 
-      const conditions: string[] = [];
-      const params: any[] = [];
-
-      // FTS conditions first
+      // Add FTS conditions
       if (filters.name) {
         conditions.push('f.name MATCH ?');
-        // For prefix searching: add "*" at the end
         params.push(`"${filters.name}"*`);
       }
       if (filters.description) {
@@ -203,48 +195,15 @@ export class ProfileRepository {
         params.push(`"${filters.location}"*`);
       }
 
-      // Non-FTS equality conditions (address, CID, registeredName)
-      if (filters.address) {
-        conditions.push('p.address LIKE ?');
-        params.push(`${filters.address}%`);
-      }
-      if (filters.CID) {
-        conditions.push('p.CID = ?');
-        params.push(filters.CID);
-      }
-      if (filters.registeredName) {
-        conditions.push('p.registeredName = ?');
-        params.push(filters.registeredName);
-      }
-
       // Join all conditions with AND
       sql += conditions.join(' AND ');
-
-      // Add a limit placeholder
-      sql += ' LIMIT ?';
-      params.push(config.maxListSize);
-
-      const results = db.prepare(sql).all(params);
-      
-      // Convert DB results to Profile objects with geoLocation array
-      return results.map((row: any): Profile => {
-        const profile: Profile = {
-          address: row.address,
-          CID: row.CID,
-          lastUpdatedAt: row.lastUpdatedAt,
-          name: row.name,
-          description: row.description,
-          registeredName: row.registeredName,
-          location: row.location
-        };
-        
-        // Add geoLocation only if both longitude and latitude exist
-        if (row.longitude !== null && row.latitude !== null) {
-          profile.geoLocation = [row.longitude, row.latitude];
-        }
-        
-        return profile;
-      });
     }
+
+    // Add limit to all queries
+    sql += ' LIMIT ?';
+    params.push(config.maxListSize);
+
+    const results = db.prepare(sql).all(params);
+    return results.map(row => this.mapRowToProfile(row));
   }
 }

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -8,7 +8,8 @@ import {Pin} from '../types'
 export class CleanupService {
   private cronJob!: CronJob;
   private cleanupInProgress: boolean = false;
-  private lastCleanUp: number = 0; // UNIX time of the last cleanup
+  // UNIX time of the last cleanup, init value = current time - cleanupInterval
+  private lastCleanUp: number = Math.floor(Date.now() / 1000) - (config.cleanupInterval * 60);
 
   constructor(private persistenceService: PersistenceService, private profileRepository: ProfileRepository) {
     logInfo('Constructing CleanupService');

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -1,74 +1,122 @@
-import config from './../config/config';
-import {logInfo} from '../utils/logger';
+import { CronJob } from 'cron';
+import {logError, logInfo} from '../utils/logger';
+import config from '../config/config';
 import {ProfileRepository} from '../repositories/profileRepo';
 import {PersistenceService} from "./persistenceService";
+import {Pin} from '../types'
 
 export class CleanupService {
-  private initialization = true;
-  private cleanupInProgress = false;
-  private chunkSize = 100;
+  private cronJob!: CronJob;
+  private cleanupInProgress: boolean = false;
+  private lastCleanUp: number = 0; // UNIX time of the last cleanup
 
   constructor(private persistenceService: PersistenceService, private profileRepository: ProfileRepository) {
     logInfo('Constructing CleanupService');
   }
 
-  initialize = async () => {
-    // @todo add as a cron process
-    // @todo this should be enableds only after full sync
+  initialize = () => {
     logInfo('Initializing CleanupService');
-    // @todo add filter by last modified
-    // the filter is only applicable to the s3
-    // @todo setup cron procedure
-    await this.cleanup();
+    
+    // Setup cron procedure to run every 20 minutes
+    this.cronJob = new CronJob(
+      `0 */${config.cleanupInterval} * * * *`,
+      async () => {
+        // If cleanup is already in progress, skip
+        if (this.cleanupInProgress) {
+          logInfo('Cleanup already in progress, skipping');
+          return;
+        }
+        
+        logInfo('Starting scheduled cleanup');
+        try {
+          await this.cleanup();
+          logInfo('Scheduled cleanup completed successfully');
+        } catch (error: any) {
+          logError(`Scheduled cleanup failed: ${error.message}`);
+        }
+      },
+      null,  // onComplete
+      true,  // start
+      null,  // timezone
+      null,  // context
+      true   // runOnInit
+    );
+    
+    // Start the cron job
+    this.cronJob.start();
+    logInfo(`Cleanup cron job started - running every ${config.cleanupInterval} minutes`);
+    
+    return Promise.resolve();
   };
-  // @todo check item type
-  // @todo check if we have an offset issue that after the items deletion the offset should not jump
 
+  /**
+   * Performs a cleanup operation by identifying and removing unused content identifiers (CIDs).
+   * 
+   * This method:
+   * 1. Retrieves all pins from the persistence service in a streaming fashion
+   * 2. Processes pins in batches (defined by config.cleanupBatchSize)
+   * 3. For each batch, determines which CIDs are no longer associated with any profiles
+   * 4. Unpins (removes) those unused CIDs from the persistence service
+   * 
+   * The cleanup runs as an atomic operation (tracked via cleanupInProgress flag)
+   * to prevent concurrent executions.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the cleanup completes
+   */
   cleanup = async () => {
-    logInfo('Cleanup started');
     this.cleanupInProgress = true;
-    let cidsBatch: {cid: string}[] = [];
+    let cidsBatch: Pin[] = [];
     let stats = {
       total: 0,
       removed: 0
     }
-    
-    const pinStream = this.persistenceService.streamPins();
+
+    const pinStream = this.persistenceService.streamPins(config.useS3 ? this.lastCleanUp : undefined)
     
     for await (const pin of pinStream) {
       // Step 1: Add CIDs to the batch
       cidsBatch.push(pin);
       stats.total++;
       
-      if (cidsBatch.length >= this.chunkSize) {
+      if (cidsBatch.length >= config.cleanupBatchSize) {
         // Process the current batch
         stats.removed += await this.processBatch(cidsBatch);
-        
-        // Add a small delay to avoid overwhelming the system
-        await new Promise(resolve => setTimeout(resolve, 100));
         
         // Empty the batch for the next iteration
         cidsBatch = [];
       }
     }
-    
+
     // Process any remaining items in the batch
     stats.removed += await this.processBatch(cidsBatch);
-    
-    console.log(`Cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
     this.cleanupInProgress = false;
+    this.lastCleanUp = Math.floor(Date.now() / 1000);
+
+    console.log(`Cleanup process completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
   }
-  // @todo improve comment 
-  // helper funciton 
-  private processBatch = async (batch: {cid: string}[]): Promise<number> => {
+
+  /**
+   * Processes a batch of Pin objects to identify and remove unused CIDs.
+   * 
+   * This helper function:
+   * 1. Extracts the CIDs from the batch of Pin objects
+   * 2. Checks with the profile repository to determine which CIDs are still in use
+   * 3. Filters the batch to find Pin objects whose CIDs are no longer referenced by any profiles
+   * 4. Removes these unused CIDs from the persistence service
+   * 
+   * @param {Pin[]} batch - An array of Pin objects to process
+   * @returns {Promise<number>} A promise that resolves to the number of items that were unpinned
+   */
+  private processBatch = async (batch: Pin[]): Promise<number> => {
     let unpinItemsCount = 0;
-      if (batch.length !== 0) {
-      
+    if (batch.length !== 0) {
       const CIDs = batch.map(pin => pin.cid);
+      
       const existResults = await this.profileRepository.checkProfilesCidsExist(CIDs);
+
       const unpinItems = batch
         .filter((_: any, index: number) => !existResults[index]);
-        
+
       if (unpinItems.length) {
         unpinItemsCount = await this.persistenceService.unpinAll(unpinItems);
       }

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -1,16 +1,15 @@
 import config from './../config/config';
-
 import {logInfo} from '../utils/logger';
-
 import {ProfileRepository} from '../repositories/profileRepo';
 import {PersistenceService} from "./persistenceService";
 
 export class CleanupService {
   private initialization = true;
-  private chunkSize = 2;
+  private cleanupInProgress = false;
+  private chunkSize = 100;
 
   constructor(private persistenceService: PersistenceService, private profileRepository: ProfileRepository) {
-    logInfo('constructing CleanupService');
+    logInfo('Constructing CleanupService');
   }
 
   initialize = async () => {
@@ -20,92 +19,61 @@ export class CleanupService {
     // @todo add filter by last modified
     // the filter is only applicable to the s3
     // @todo setup cron procedure
-    if(config.useS3) {
-      await this.cleanupS3();
-    } else {
-      await this.cleanupKubo();
-    }
+    await this.cleanup();
   };
   // @todo check item type
   // @todo check if we have an offset issue that after the items deletion the offset should not jump
-  cleanupS3 = async () => {
-    let offset = 0;
-    let hasMoreItems = true;
-    
-    while (hasMoreItems) {
-      // Step 1: Get a chunk of items with their keys and CIDs
-      const items = await this.persistenceService.listItems(offset, this.chunkSize);
-      
-      if (items.length === 0) {
-        hasMoreItems = false;
-        break;
-      }
 
-      console.log(`Processing chunk of ${items.length} items (offset: ${offset})...`);
-      
-      // Step 2: Extract CIDs from the items to check existence
-      const cids = items.map((item:any) => item.cid);
-      // Step 3: Check which CIDs exist in the profiles database
-      const existResults = await this.profileRepository.checkProfilesCidsExist(cids);
-      
-      // Step 4: Find keys of items whose CIDs don't exist in the profiles database
-      const keysToUnpin = items
-        .filter((_: any, index: number) => !existResults[index])
-        .filter((item: any) => item.key !== undefined); // Filter out undefined keys
-      //console.log(keysToUnpin)
-      // Only attempt to unpin if there are keys to unpin
-      if (keysToUnpin.length > 0) {
-        const unpinResult = await this.persistenceService.unpinAll(keysToUnpin);
-
-        if(!unpinResult) {
-          // @todo update error description
-          console.log("Error unpinning keys:", keysToUnpin);
-        }
-      }
-      
-      // Step 5: Move to the next chunk
-      offset += this.chunkSize;
-      
-      // Optional: Add a small delay to avoid overwhelming the system
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-    
-    console.log(`Cleanup completed.`);
-  }
-
-  cleanupKubo = async () => {
-    let cidsBatch: string[] = [];
+  cleanup = async () => {
+    logInfo('Cleanup started');
+    this.cleanupInProgress = true;
+    let cidsBatch: {cid: string}[] = [];
     let stats = {
       total: 0,
       removed: 0
     }
-
+    
     const pinStream = this.persistenceService.streamPins();
-
+    
     for await (const pin of pinStream) {
       // Step 1: Add CIDs to the batch
-      cidsBatch.push(pin.cid.toString());
+      cidsBatch.push(pin);
       stats.total++;
-
-      if(cidsBatch.length >= this.chunkSize) {
-        // Step 2: Check which CIDs utilized in the profiles database
-        const existResults = await this.profileRepository.checkProfilesCidsExist(cidsBatch);
-        const unpinItems = cidsBatch
-          .filter((_: any, index:number) => !existResults[index]);
-
-        // Step 4: Unpin CIDs that are not used in the profiles database
-        if(unpinItems.length) {
-          const unpinItemsCount = await this.persistenceService.unpinAll(unpinItems);
-          stats.removed += unpinItemsCount;
-        }
+      
+      if (cidsBatch.length >= this.chunkSize) {
+        // Process the current batch
+        stats.removed += await this.processBatch(cidsBatch);
+        
         // Add a small delay to avoid overwhelming the system
         await new Promise(resolve => setTimeout(resolve, 100));
-
-        // Step 4: Empty the batch for the next iteration
+        
+        // Empty the batch for the next iteration
         cidsBatch = [];
       }
     }
-
-    console.log(`IPFS cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
+    
+    // Process any remaining items in the batch
+    stats.removed += await this.processBatch(cidsBatch);
+    
+    console.log(`Cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
+    this.cleanupInProgress = false;
   }
+  // @todo improve comment 
+  // helper funciton 
+  private processBatch = async (batch: {cid: string}[]): Promise<number> => {
+    let unpinItemsCount = 0;
+      if (batch.length !== 0) {
+      
+      const CIDs = batch.map(pin => pin.cid);
+      const existResults = await this.profileRepository.checkProfilesCidsExist(CIDs);
+      const unpinItems = batch
+        .filter((_: any, index: number) => !existResults[index]);
+        
+      if (unpinItems.length) {
+        unpinItemsCount = await this.persistenceService.unpinAll(unpinItems);
+      }
+    }
+
+    return unpinItemsCount;
+  };
 }

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -1,3 +1,5 @@
+import config from './../config/config';
+
 import {logInfo} from '../utils/logger';
 
 import {ProfileRepository} from '../repositories/profileRepo';
@@ -5,7 +7,7 @@ import {PersistenceService} from "./persistenceService";
 
 export class CleanupService {
   private initialization = true;
-  private chunkSize = 1000;
+  private chunkSize = 2;
 
   constructor(private persistenceService: PersistenceService, private profileRepository: ProfileRepository) {
     logInfo('constructing CleanupService');
@@ -14,30 +16,21 @@ export class CleanupService {
   initialize = async () => {
     // @todo add as a cron process
     // @todo this should be enableds only after full sync
-      logInfo('Initializing CleanupService');
-      // @todo add filter by last modified
-      // the filter is only applicable to the s3
-
-      // @todo it should be ()
-      if(await this.persistenceService.isHealthy()) {
-        // get chunk of keys with cid or cid
-        // get chunk if such cids exists
-        // call delete with some props which are false for the mentioned cunck
-        await this.cleanupS3();
-        //await this.cleanupKubo();
-
-    
-      }
+    logInfo('Initializing CleanupService');
+    // @todo add filter by last modified
+    // the filter is only applicable to the s3
+    // @todo setup cron procedure
+    if(config.useS3) {
+      await this.cleanupS3();
+    } else {
+      await this.cleanupKubo();
+    }
   };
   // @todo check item type
   // @todo check if we have an offset issue that after the items deletion the offset should not jump
   cleanupS3 = async () => {
     let offset = 0;
     let hasMoreItems = true;
-    let stats = {
-      total: 0,
-      removed: 0
-    };
     
     while (hasMoreItems) {
       // Step 1: Get a chunk of items with their keys and CIDs
@@ -47,8 +40,7 @@ export class CleanupService {
         hasMoreItems = false;
         break;
       }
-      
-      stats.total += items.length;
+
       console.log(`Processing chunk of ${items.length} items (offset: ${offset})...`);
       
       // Step 2: Extract CIDs from the items to check existence
@@ -58,15 +50,13 @@ export class CleanupService {
       
       // Step 4: Find keys of items whose CIDs don't exist in the profiles database
       const keysToUnpin = items
-        .filter((item:any, index: number) => !existResults[index])
+        .filter((_: any, index: number) => !existResults[index])
         .filter((item: any) => item.key !== undefined); // Filter out undefined keys
       //console.log(keysToUnpin)
       // Only attempt to unpin if there are keys to unpin
       if (keysToUnpin.length > 0) {
-        stats.removed += keysToUnpin.length;
-  
-        console.log(keysToUnpin)
         const unpinResult = await this.persistenceService.unpinAll(keysToUnpin);
+
         if(!unpinResult) {
           // @todo update error description
           console.log("Error unpinning keys:", keysToUnpin);
@@ -80,53 +70,42 @@ export class CleanupService {
       await new Promise(resolve => setTimeout(resolve, 100));
     }
     
-    console.log(`Cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused items.`);
-    return stats;
+    console.log(`Cleanup completed.`);
   }
 
   cleanupKubo = async () => {
-    let offset = 0;
-    let hasMoreItems = true;
+    let cidsBatch: string[] = [];
     let stats = {
       total: 0,
       removed: 0
-    };
-    
-    while (hasMoreItems) {
-      // Step 1: Get a chunk of items with their CIDs
-      const items = await this.persistenceService.listItems(this.chunkSize, offset);
-      
-      if (items.length === 0) {
-        hasMoreItems = false;
-        break;
-      }
-      
-      stats.total += items.length;
-      console.log(`Processing chunk of ${items.length} items (offset: ${offset})...`);
-      
-      // Step 2: Extract CIDs from the items
-      const cids = items.map((item: {cid: string, type: string}) => item.cid);
-      
-      // Step 3: Check which CIDs exist in the profiles database
-      const existResults = await this.profileRepository.checkProfilesCidsExist(cids);
-      
-      // Step 4: Unpin CIDs that don't exist in the profiles database
-      const unpinItems = items.map((item: {cid: string, type: string}) => item.cid);
-      const unpinResult = await this.persistenceService.unpinAll(unpinItems);
-      if(!unpinResult) {
-        // @todo update error description
-        console.log("Error");
-      }
-      
-      // Step 5: Move to the next chunk
-      offset += this.chunkSize;
-      
-      // Optional: Add a small delay to avoid overwhelming the system
-      await new Promise(resolve => setTimeout(resolve, 100));
     }
-    
-    console.log(`CID cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
-    return stats;
+
+    const pinStream = this.persistenceService.streamPins();
+
+    for await (const pin of pinStream) {
+      // Step 1: Add CIDs to the batch
+      cidsBatch.push(pin.cid.toString());
+      stats.total++;
+
+      if(cidsBatch.length >= this.chunkSize) {
+        // Step 2: Check which CIDs utilized in the profiles database
+        const existResults = await this.profileRepository.checkProfilesCidsExist(cidsBatch);
+        const unpinItems = cidsBatch
+          .filter((_: any, index:number) => !existResults[index]);
+
+        // Step 4: Unpin CIDs that are not used in the profiles database
+        if(unpinItems.length) {
+          const unpinItemsCount = await this.persistenceService.unpinAll(unpinItems);
+          stats.removed += unpinItemsCount;
+        }
+        // Add a small delay to avoid overwhelming the system
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Step 4: Empty the batch for the next iteration
+        cidsBatch = [];
+      }
+    }
+
+    console.log(`IPFS cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
   }
-  // @todo maybe we should also remove it from some cache
 }

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -1,0 +1,132 @@
+import {logInfo} from '../utils/logger';
+
+import {ProfileRepository} from '../repositories/profileRepo';
+import {PersistenceService} from "./persistenceService";
+
+export class CleanupService {
+  private initialization = true;
+  private chunkSize = 1000;
+
+  constructor(private persistenceService: PersistenceService, private profileRepository: ProfileRepository) {
+    logInfo('constructing CleanupService');
+  }
+
+  initialize = async () => {
+    // @todo add as a cron process
+    // @todo this should be enableds only after full sync
+      logInfo('Initializing CleanupService');
+      // @todo add filter by last modified
+      // the filter is only applicable to the s3
+
+      // @todo it should be ()
+      if(await this.persistenceService.isHealthy()) {
+        // get chunk of keys with cid or cid
+        // get chunk if such cids exists
+        // call delete with some props which are false for the mentioned cunck
+        await this.cleanupS3();
+        //await this.cleanupKubo();
+
+    
+      }
+  };
+  // @todo check item type
+  // @todo check if we have an offset issue that after the items deletion the offset should not jump
+  cleanupS3 = async () => {
+    let offset = 0;
+    let hasMoreItems = true;
+    let stats = {
+      total: 0,
+      removed: 0
+    };
+    
+    while (hasMoreItems) {
+      // Step 1: Get a chunk of items with their keys and CIDs
+      const items = await this.persistenceService.listItems(offset, this.chunkSize);
+      
+      if (items.length === 0) {
+        hasMoreItems = false;
+        break;
+      }
+      
+      stats.total += items.length;
+      console.log(`Processing chunk of ${items.length} items (offset: ${offset})...`);
+      
+      // Step 2: Extract CIDs from the items to check existence
+      const cids = items.map((item:any) => item.cid);
+      // Step 3: Check which CIDs exist in the profiles database
+      const existResults = await this.profileRepository.checkProfilesCidsExist(cids);
+      
+      // Step 4: Find keys of items whose CIDs don't exist in the profiles database
+      const keysToUnpin = items
+        .filter((item:any, index: number) => !existResults[index])
+        .filter((item: any) => item.key !== undefined); // Filter out undefined keys
+      //console.log(keysToUnpin)
+      // Only attempt to unpin if there are keys to unpin
+      if (keysToUnpin.length > 0) {
+        stats.removed += keysToUnpin.length;
+  
+        console.log(keysToUnpin)
+        const unpinResult = await this.persistenceService.unpinAll(keysToUnpin);
+        if(!unpinResult) {
+          // @todo update error description
+          console.log("Error unpinning keys:", keysToUnpin);
+        }
+      }
+      
+      // Step 5: Move to the next chunk
+      offset += this.chunkSize;
+      
+      // Optional: Add a small delay to avoid overwhelming the system
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    
+    console.log(`Cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused items.`);
+    return stats;
+  }
+
+  cleanupKubo = async () => {
+    let offset = 0;
+    let hasMoreItems = true;
+    let stats = {
+      total: 0,
+      removed: 0
+    };
+    
+    while (hasMoreItems) {
+      // Step 1: Get a chunk of items with their CIDs
+      const items = await this.persistenceService.listItems(this.chunkSize, offset);
+      
+      if (items.length === 0) {
+        hasMoreItems = false;
+        break;
+      }
+      
+      stats.total += items.length;
+      console.log(`Processing chunk of ${items.length} items (offset: ${offset})...`);
+      
+      // Step 2: Extract CIDs from the items
+      const cids = items.map((item: {cid: string, type: string}) => item.cid);
+      
+      // Step 3: Check which CIDs exist in the profiles database
+      const existResults = await this.profileRepository.checkProfilesCidsExist(cids);
+      
+      // Step 4: Unpin CIDs that don't exist in the profiles database
+      const unpinItems = items.map((item: {cid: string, type: string}) => item.cid);
+      const unpinResult = await this.persistenceService.unpinAll(unpinItems);
+      if(!unpinResult) {
+        // @todo update error description
+        console.log("Error");
+      }
+      
+      // Step 5: Move to the next chunk
+      offset += this.chunkSize;
+      
+      // Optional: Add a small delay to avoid overwhelming the system
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    
+    console.log(`CID cleanup completed. Processed ${stats.total} items, removed ${stats.removed} unused CIDs.`);
+    return stats;
+  }
+  // @todo maybe we should also remove it from some cache
+}

--- a/src/services/kuboService.ts
+++ b/src/services/kuboService.ts
@@ -1,20 +1,19 @@
 import {LRUCache} from 'lru-cache';
 import {logError, logInfo} from '../utils/logger';
-import {IPFSDataProfile} from '../types';
+import {IPFSDataProfile, Pin} from '../types';
 import config from '../config/config';
 import {CacheService} from "../utils/cache";
 import {PersistenceService} from "./persistenceService";
 import {ProfileValidator} from "./profileValidator";
 
 export class KuboService implements PersistenceService {
-  // @todo fix types
   public ipfs: any;
 
   profileCache: CacheService<IPFSDataProfile>;
   blackList = new LRUCache<string, any>({max: 100000});
 
   constructor() {
-    logInfo('constructing KuboService');
+    logInfo('Constructing KuboService');
 
     this.profileCache = new CacheService<IPFSDataProfile>(
       config.cacheMaxSize,
@@ -39,15 +38,15 @@ export class KuboService implements PersistenceService {
     await this.ipfs.pin.add(result.cid);
     return result.cid.toString();
   }
-  // @todo make enum for types
-  async unpinAll(pins: {cid: string}[]): Promise<number> {
+
+  async unpinAll(pins: Pin[]): Promise<number> {
     const cids = pins.map(pin => pin.cid);
 
     try {
       // Prepare batch unpinning options based on pin type
       // Use rmAll to process all CIDs in a batch
       let unpinnedCounter = 0;
-      // @todo do not apply recursive unpin to all
+      // @dev We apply `recursive` removal for simplicity for all pin types
       for await (const result of this.ipfs.pin.rmAll(cids, { recursive: true })) {
         unpinnedCounter++;
       }
@@ -64,20 +63,18 @@ export class KuboService implements PersistenceService {
         cids.map(cid => this.profileCache.delete(cid))
       );
 
-      // Report final repo size
+      // Report unpinned items
       logInfo(`Unpinned CIDs: ${cids.join(', ')}`);
       return unpinnedCounter;
-
     } catch (error) {
       logError('Failed to unpin CIDs:', error);
       return 0;
     }
   }
 
-  async *streamPins() {
+  async *streamPins(): AsyncGenerator<Pin> {
     try {
       for await (const pin of this.ipfs.pin.ls()) {
-        // @todo doublecheck if it works correctly
         yield {
           cid: pin.cid.toString()
         };

--- a/src/services/kuboService.ts
+++ b/src/services/kuboService.ts
@@ -40,7 +40,9 @@ export class KuboService implements PersistenceService {
     return result.cid.toString();
   }
   // @todo make enum for types
-  async unpinAll(cids: string[]): Promise<number> {
+  async unpinAll(pins: {cid: string}[]): Promise<number> {
+    const cids = pins.map(pin => pin.cid);
+
     try {
       // Prepare batch unpinning options based on pin type
       // Use rmAll to process all CIDs in a batch
@@ -51,7 +53,6 @@ export class KuboService implements PersistenceService {
       }
 
       // Run garbage collection after batch operation is complete
-      console.log("Running IPFS garbage collection...");
       for await (const gcResult of this.ipfs.repo.gc({ quiet: false })) {
         if(gcResult.err) {
           logInfo(`Error on garbage collection for item: ${gcResult.cid}`);
@@ -68,7 +69,7 @@ export class KuboService implements PersistenceService {
       return unpinnedCounter;
 
     } catch (error) {
-      logError(`Error unpinning:`, error);
+      logError('Failed to unpin CIDs:', error);
       return 0;
     }
   }
@@ -76,7 +77,10 @@ export class KuboService implements PersistenceService {
   async *streamPins() {
     try {
       for await (const pin of this.ipfs.pin.ls()) {
-        yield pin;
+        // @todo doublecheck if it works correctly
+        yield {
+          cid: pin.cid.toString()
+        };
       }
     } catch (error) {
       logError('Error streaming IPFS pins:', error);

--- a/src/services/kuboService.ts
+++ b/src/services/kuboService.ts
@@ -40,70 +40,47 @@ export class KuboService implements PersistenceService {
     return result.cid.toString();
   }
   // @todo make enum for types
-  async unpinAll(cids: string[]): Promise<boolean> {
-
+  async unpinAll(cids: string[]): Promise<number> {
     try {
       // Prepare batch unpinning options based on pin type
       // Use rmAll to process all CIDs in a batch
       let unpinnedCounter = 0;
       // @todo do not apply recursive unpin to all
       for await (const result of this.ipfs.pin.rmAll(cids, { recursive: true })) {
-        logInfo(`Unpinned: ${result}`);
         unpinnedCounter++;
       }
-      
+
       // Run garbage collection after batch operation is complete
-      console.log("Running garbage collection...");
+      console.log("Running IPFS garbage collection...");
       for await (const gcResult of this.ipfs.repo.gc({ quiet: false })) {
-        logInfo(gcResult);
+        if(gcResult.err) {
+          logInfo(`Error on garbage collection for item: ${gcResult.cid}`);
+        }
       }
-      
+
       // Delete items from cache
-      const cacheResults = await Promise.all(
+      await Promise.all(
         cids.map(cid => this.profileCache.delete(cid))
       );
-      
+
       // Report final repo size
-      logInfo(`Successfully unpinned ${unpinnedCounter} CIDs`);
-      
-      return unpinnedCounter === cids.length;
+      logInfo(`Unpinned CIDs: ${cids.join(', ')}`);
+      return unpinnedCounter;
 
     } catch (error) {
       logError(`Error unpinning:`, error);
-      return false;
+      return 0;
     }
   }
 
-  async listItems(offset = 0, limit = 10): Promise<{cid: string, type: string}[]> {
+  async *streamPins() {
     try {
-      // Array to store pinned items
-      const pinnedItems = [];
-      let skipped = 0;
-
-      // Iterate through pinned items
       for await (const pin of this.ipfs.pin.ls()) {
-        // Skip items until we reach the offset
-        if (skipped < offset) {
-          skipped++;
-          continue;
-        }
-  
-        // Add item to the list
-        pinnedItems.push({
-          cid: pin.cid.toString(), // CID of the pinned item
-          type: pin.type, // Type of pin (direct, recursive, etc.)
-        });
-
-        // Break if we've reached the limit
-        if (pinnedItems.length >= limit) {
-          break;
-        }
+        yield pin;
       }
-
-      return pinnedItems;
     } catch (error) {
-      logError('Error retrieving pinned IPFS items:', error);
-      return [];
+      logError('Error streaming IPFS pins:', error);
+      throw error;
     }
   }
 

--- a/src/services/kuboService.ts
+++ b/src/services/kuboService.ts
@@ -7,7 +7,8 @@ import {PersistenceService} from "./persistenceService";
 import {ProfileValidator} from "./profileValidator";
 
 export class KuboService implements PersistenceService {
-  private ipfs: any;
+  // @todo fix types
+  public ipfs: any;
 
   profileCache: CacheService<IPFSDataProfile>;
   blackList = new LRUCache<string, any>({max: 100000});
@@ -37,6 +38,73 @@ export class KuboService implements PersistenceService {
     const result = await this.ipfs.add(buffer);
     await this.ipfs.pin.add(result.cid);
     return result.cid.toString();
+  }
+  // @todo make enum for types
+  async unpinAll(cids: string[]): Promise<boolean> {
+
+    try {
+      // Prepare batch unpinning options based on pin type
+      // Use rmAll to process all CIDs in a batch
+      let unpinnedCounter = 0;
+      // @todo do not apply recursive unpin to all
+      for await (const result of this.ipfs.pin.rmAll(cids, { recursive: true })) {
+        logInfo(`Unpinned: ${result}`);
+        unpinnedCounter++;
+      }
+      
+      // Run garbage collection after batch operation is complete
+      console.log("Running garbage collection...");
+      for await (const gcResult of this.ipfs.repo.gc({ quiet: false })) {
+        logInfo(gcResult);
+      }
+      
+      // Delete items from cache
+      const cacheResults = await Promise.all(
+        cids.map(cid => this.profileCache.delete(cid))
+      );
+      
+      // Report final repo size
+      logInfo(`Successfully unpinned ${unpinnedCounter} CIDs`);
+      
+      return unpinnedCounter === cids.length;
+
+    } catch (error) {
+      logError(`Error unpinning:`, error);
+      return false;
+    }
+  }
+
+  async listItems(offset = 0, limit = 10): Promise<{cid: string, type: string}[]> {
+    try {
+      // Array to store pinned items
+      const pinnedItems = [];
+      let skipped = 0;
+
+      // Iterate through pinned items
+      for await (const pin of this.ipfs.pin.ls()) {
+        // Skip items until we reach the offset
+        if (skipped < offset) {
+          skipped++;
+          continue;
+        }
+  
+        // Add item to the list
+        pinnedItems.push({
+          cid: pin.cid.toString(), // CID of the pinned item
+          type: pin.type, // Type of pin (direct, recursive, etc.)
+        });
+
+        // Break if we've reached the limit
+        if (pinnedItems.length >= limit) {
+          break;
+        }
+      }
+
+      return pinnedItems;
+    } catch (error) {
+      logError('Error retrieving pinned IPFS items:', error);
+      return [];
+    }
   }
 
   initialize = async () => {
@@ -88,7 +156,7 @@ export class KuboService implements PersistenceService {
       }
     } catch (error) {
       logError('Failed to fetch profile from IPFS', error);
-      throw new Error('Failed to fetch profile from IPFS');
+      return undefined;
     }
 
     let profile: any;

--- a/src/services/persistenceService.ts
+++ b/src/services/persistenceService.ts
@@ -3,6 +3,9 @@ import {LRUCache} from "lru-cache";
 import {IPFSDataProfile} from "../types";
 
 export interface PersistenceService {
+  // @todo fix types
+  ipfs?: any;
+  listItems?: any;
   /**
    * In-memory cache service for IPFSDataProfile objects.
    */
@@ -64,4 +67,7 @@ export interface PersistenceService {
    * Checks if the storage service is healthy.
    */
   isHealthy(): Promise<boolean>;
+  // @todo update types
+  // @todo add comments
+  unpinAll(itemsToDelete: string[] | {cid: string, key: string}[]): any;
 }

--- a/src/services/persistenceService.ts
+++ b/src/services/persistenceService.ts
@@ -67,7 +67,8 @@ export interface PersistenceService {
    * Checks if the storage service is healthy.
    */
   isHealthy(): Promise<boolean>;
-  // @todo update types
+  // @todo fix types
   // @todo add comments
   unpinAll(itemsToDelete: string[] | {cid: string, key: string}[]): any;
+  streamPins?: any;
 }

--- a/src/services/persistenceService.ts
+++ b/src/services/persistenceService.ts
@@ -69,6 +69,6 @@ export interface PersistenceService {
   isHealthy(): Promise<boolean>;
   // @todo fix types
   // @todo add comments
-  unpinAll(itemsToDelete: string[] | {cid: string, key: string}[]): any;
+  unpinAll(itemsToDelete: string[] | {cid: string, key: string}[] | {cid: string}[]): any;
   streamPins?: any;
 }

--- a/src/services/persistenceService.ts
+++ b/src/services/persistenceService.ts
@@ -1,11 +1,8 @@
 import {CacheService} from "../utils/cache";
 import {LRUCache} from "lru-cache";
-import {IPFSDataProfile} from "../types";
+import {IPFSDataProfile, Pin} from "../types";
 
 export interface PersistenceService {
-  // @todo fix types
-  ipfs?: any;
-  listItems?: any;
   /**
    * In-memory cache service for IPFSDataProfile objects.
    */
@@ -67,8 +64,21 @@ export interface PersistenceService {
    * Checks if the storage service is healthy.
    */
   isHealthy(): Promise<boolean>;
-  // @todo fix types
-  // @todo add comments
-  unpinAll(itemsToDelete: string[] | {cid: string, key: string}[] | {cid: string}[]): any;
-  streamPins?: any;
+
+  /**
+   * Unpins multiple content identifiers from the IPFS node or an S3 bucket.
+   * 
+   * @param pins - Array of Pin objects containing the CIDs and storage keys to unpin.
+   * @returns A promise that resolves to the number of successfully unpinned items.
+   */
+  unpinAll(pinsToDelete: Pin[]): Promise<number>;
+
+  /**
+   * Creates an async generator that streams all pins and metadata from the IPFS node or an S3 bucket.
+   * 
+   * @param lastCleanUp - UNIX time when the last cleanup procedure finished.
+   * @returns An AsyncGenerator that yields Pin objects containing CIDs.
+   * @throws Error if the streaming operation fails.
+   */
+  streamPins(lastCleanUp?: number): AsyncGenerator<Pin>
 }

--- a/src/services/pinningService.ts
+++ b/src/services/pinningService.ts
@@ -11,6 +11,8 @@ import {ProfileValidator} from './profileValidator';
 import AWS from "aws-sdk";
 
 export class PinningService implements PersistenceService {
+  //@todo fix types
+  ipfs: any;
   profileCache: CacheService<IPFSDataProfile>;
   blackList = new LRUCache<string, any>({max: 100000});
 
@@ -58,6 +60,138 @@ export class PinningService implements PersistenceService {
         reject(err);
       }
     });
+  }
+
+  // @todo improve comments / returns list of keys and cids to delete
+  async listItems(offset: number = 0, limit: number = 10): Promise<{ cid: string, key?: string, createdAt?: number }[]> {
+    logInfo('Listing pinned CIDs via S3 API');
+  
+    try {
+      const s3 = new AWS.S3({
+        endpoint: config.s3ApiUrl,
+        region: 'us-east-1',
+        signatureVersion: 'v4',
+        accessKeyId: config.s3Key,
+        secretAccessKey: config.s3Secret,
+      });
+  
+      const listParams: AWS.S3.ListObjectsV2Request = {
+        Bucket: config.s3Bucket as string,
+        MaxKeys: 1000 // Use maximum allowed to efficiently paginate
+      };
+  
+      const pinnedItems: { cid: string, key?: string, createdAt?: number }[] = [];
+      let truncated = true;
+      let continuationToken: string | undefined;
+      let itemsProcessed = 0;
+  
+      // Paginate through objects until we reach the desired offset + limit
+      while (truncated && pinnedItems.length < limit) {
+        if (continuationToken) {
+          listParams.ContinuationToken = continuationToken;
+        }
+        
+        const response = await s3.listObjectsV2(listParams).promise();
+        truncated = !!response.IsTruncated;
+        continuationToken = response.NextContinuationToken;
+        
+        if (response.Contents) {
+          // Get metadata for each object to extract CID
+          const objectDetailsPromises = response.Contents.map(async (object) => {
+            try {
+              const headParams = {
+                Bucket: config.s3Bucket as string,
+                Key: object.Key as string
+              };
+              
+              const metadata = await s3.headObject(headParams).promise();
+              const cid = metadata.Metadata?.['cid'] || metadata.Metadata?.['x-amz-meta-cid'];
+              if (cid) {
+                return {
+                  cid,
+                  key: object.Key,
+                  createdAt: object.LastModified ? Math.floor(object.LastModified.getTime() / 1000) : undefined
+                };
+              }
+              return null;
+            } catch (err) {
+              logError(`Failed to get metadata for object: ${object.Key}`, err);
+              return null;
+            }
+          });
+          
+          const objectDetails = await Promise.all(objectDetailsPromises);
+          const validObjects = objectDetails.filter(item => item !== null) as { cid: string, key?: string, createdAt?: number }[];
+          
+          // Apply offset and limit logic
+          if (itemsProcessed + validObjects.length > offset) {
+            // Calculate how many items to skip from this batch
+            const skipCount = Math.max(0, offset - itemsProcessed);
+            // Calculate how many items to take from this batch
+            const takeCount = Math.min(limit - pinnedItems.length, validObjects.length - skipCount);
+            
+            // Add relevant items to the result
+            pinnedItems.push(...validObjects.slice(skipCount, skipCount + takeCount));
+          }
+          
+          itemsProcessed += validObjects.length;
+          
+          // If we've processed enough items to satisfy the limit, break the loop
+          if (pinnedItems.length >= limit || !truncated) {
+            break;
+          }
+        }
+      }
+  
+      return pinnedItems;
+    } catch (err) {
+      logError('Failed to list pinned CIDs', err);
+      throw err;
+    }
+  }
+  // @todo update input
+  async unpinAll(itemsToDelete: {cid: string, key: string, createdAt?: number}[]): Promise<boolean> {
+    // @todo delete from cache
+    try {
+      const s3 = new AWS.S3({
+        endpoint: config.s3ApiUrl,
+        region: 'us-east-1',
+        signatureVersion: 'v4',
+        accessKeyId: config.s3Key,
+        secretAccessKey: config.s3Secret,
+      });
+
+      // Delete objects one by one
+      const deleteResults = [];
+      for (const item of itemsToDelete) {
+        const deleteParams = {
+          Bucket: config.s3Bucket as string,
+          Key: item.key
+        };
+
+        // Delete item from cache
+        await this.profileCache.delete(item.cid);
+        
+        try {
+          // Delete a single object and await its completion
+          const result = await s3.deleteObject(deleteParams).promise();
+          deleteResults.push({
+            Key: item.key,
+            Status: "DELETED",
+          });
+          // @todo remove from cache
+          logInfo(`Successfully deleted: ${item.key}`);
+        } catch (error) {
+          logError(`Error deleting object ${item.key}:`, error);
+        }
+      }
+
+      return deleteResults.length > 0;
+
+    } catch (err) {
+      logError(`Failed to unpin CID: ${itemsToDelete.length}`, err);
+      throw err;
+    }
   }
 
   initialize = async () => {

--- a/src/services/pinningService.ts
+++ b/src/services/pinningService.ts
@@ -61,11 +61,9 @@ export class PinningService implements PersistenceService {
       }
     });
   }
-
-  // @todo improve comments / returns list of keys and cids to delete
-  async listItems(offset: number = 0, limit: number = 10): Promise<{ cid: string, key?: string, createdAt?: number }[]> {
-    logInfo('Listing pinned CIDs via S3 API');
-  
+  // @todo update types
+  // @todo doublecheck the logic
+  async *streamPins(): AsyncGenerator<{ cid: string, key?: string, createdAt?: number }> {    
     try {
       const s3 = new AWS.S3({
         endpoint: config.s3ApiUrl,
@@ -74,19 +72,17 @@ export class PinningService implements PersistenceService {
         accessKeyId: config.s3Key,
         secretAccessKey: config.s3Secret,
       });
-  
+      
       const listParams: AWS.S3.ListObjectsV2Request = {
         Bucket: config.s3Bucket as string,
         MaxKeys: 1000 // Use maximum allowed to efficiently paginate
       };
-  
-      const pinnedItems: { cid: string, key?: string, createdAt?: number }[] = [];
+      
       let truncated = true;
       let continuationToken: string | undefined;
-      let itemsProcessed = 0;
-  
-      // Paginate through objects until we reach the desired offset + limit
-      while (truncated && pinnedItems.length < limit) {
+      
+      // Paginate through objects
+      while (truncated) {
         if (continuationToken) {
           listParams.ContinuationToken = continuationToken;
         }
@@ -96,8 +92,8 @@ export class PinningService implements PersistenceService {
         continuationToken = response.NextContinuationToken;
         
         if (response.Contents) {
-          // Get metadata for each object to extract CID
-          const objectDetailsPromises = response.Contents.map(async (object) => {
+          // Process each object sequentially instead of using Promise.all
+          for (const object of response.Contents) {
             try {
               const headParams = {
                 Bucket: config.s3Bucket as string,
@@ -106,53 +102,36 @@ export class PinningService implements PersistenceService {
               
               const metadata = await s3.headObject(headParams).promise();
               const cid = metadata.Metadata?.['cid'] || metadata.Metadata?.['x-amz-meta-cid'];
+              
               if (cid) {
-                return {
+                yield {
                   cid,
                   key: object.Key,
                   createdAt: object.LastModified ? Math.floor(object.LastModified.getTime() / 1000) : undefined
                 };
               }
-              return null;
             } catch (err) {
               logError(`Failed to get metadata for object: ${object.Key}`, err);
-              return null;
+              // Continue with next object
             }
-          });
-          
-          const objectDetails = await Promise.all(objectDetailsPromises);
-          const validObjects = objectDetails.filter(item => item !== null) as { cid: string, key?: string, createdAt?: number }[];
-          
-          // Apply offset and limit logic
-          if (itemsProcessed + validObjects.length > offset) {
-            // Calculate how many items to skip from this batch
-            const skipCount = Math.max(0, offset - itemsProcessed);
-            // Calculate how many items to take from this batch
-            const takeCount = Math.min(limit - pinnedItems.length, validObjects.length - skipCount);
-            
-            // Add relevant items to the result
-            pinnedItems.push(...validObjects.slice(skipCount, skipCount + takeCount));
-          }
-          
-          itemsProcessed += validObjects.length;
-          
-          // If we've processed enough items to satisfy the limit, break the loop
-          if (pinnedItems.length >= limit || !truncated) {
-            break;
           }
         }
+        
+        // If no more pages, break the loop
+        if (!truncated) {
+          break;
+        }
       }
-  
-      return pinnedItems;
     } catch (err) {
       logError('Failed to list pinned CIDs', err);
       throw err;
     }
   }
+
   // @todo update input
-  async unpinAll(itemsToDelete: {cid: string, key: string, createdAt?: number}[]): Promise<boolean> {
-    // @todo delete from cache
+  async unpinAll(pins: {cid: string, key: string, createdAt?: number}[]): Promise<number> {
     try {
+      let unpinnedCounter = 0;
       const s3 = new AWS.S3({
         endpoint: config.s3ApiUrl,
         region: 'us-east-1',
@@ -162,35 +141,29 @@ export class PinningService implements PersistenceService {
       });
 
       // Delete objects one by one
-      const deleteResults = [];
-      for (const item of itemsToDelete) {
+      for (const pin of pins) {
         const deleteParams = {
           Bucket: config.s3Bucket as string,
-          Key: item.key
+          Key: pin.key
         };
-
-        // Delete item from cache
-        await this.profileCache.delete(item.cid);
         
         try {
           // Delete a single object and await its completion
-          const result = await s3.deleteObject(deleteParams).promise();
-          deleteResults.push({
-            Key: item.key,
-            Status: "DELETED",
-          });
-          // @todo remove from cache
-          logInfo(`Successfully deleted: ${item.key}`);
+          await s3.deleteObject(deleteParams).promise();
+
+          // Delete item from cache
+          await this.profileCache.delete(pin.cid);
+          unpinnedCounter++;
         } catch (error) {
-          logError(`Error deleting object ${item.key}:`, error);
+          logError(`Error deleting object ${pin.key} - ${pin.cid}:`, error);
         }
       }
+      logInfo(`Unpinned CIDs: ${pins.map(pin => pin.cid).join(', ')}`);
+      return unpinnedCounter;
 
-      return deleteResults.length > 0;
-
-    } catch (err) {
-      logError(`Failed to unpin CID: ${itemsToDelete.length}`, err);
-      throw err;
+    } catch (error) {
+      logError('Failed to unpin CIDs:', error);
+      return 0;
     }
   }
 

--- a/src/services/pinningService.ts
+++ b/src/services/pinningService.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import {v4 as uuidv4} from 'uuid';
 import {logError, logInfo} from '../utils/logger';
 import {LRUCache} from 'lru-cache';
-import {IPFSDataProfile} from '../types';
+import {IPFSDataProfile, Pin} from '../types';
 import config from '../config/config';
 import {CacheService} from '../utils/cache';
 import {PersistenceService} from './persistenceService';
@@ -11,8 +11,6 @@ import {ProfileValidator} from './profileValidator';
 import AWS from "aws-sdk";
 
 export class PinningService implements PersistenceService {
-  //@todo fix types
-  ipfs: any;
   profileCache: CacheService<IPFSDataProfile>;
   blackList = new LRUCache<string, any>({max: 100000});
 
@@ -61,9 +59,8 @@ export class PinningService implements PersistenceService {
       }
     });
   }
-  // @todo update types
-  // @todo doublecheck the logic
-  async *streamPins(): AsyncGenerator<{ cid: string, key?: string, createdAt?: number }> {    
+
+  async *streamPins(lastCleanUp: number): AsyncGenerator<Pin> {
     try {
       const s3 = new AWS.S3({
         endpoint: config.s3ApiUrl,
@@ -95,20 +92,23 @@ export class PinningService implements PersistenceService {
           // Process each object sequentially instead of using Promise.all
           for (const object of response.Contents) {
             try {
-              const headParams = {
-                Bucket: config.s3Bucket as string,
-                Key: object.Key as string
-              };
-              
-              const metadata = await s3.headObject(headParams).promise();
-              const cid = metadata.Metadata?.['cid'] || metadata.Metadata?.['x-amz-meta-cid'];
-              
-              if (cid) {
-                yield {
-                  cid,
-                  key: object.Key,
-                  createdAt: object.LastModified ? Math.floor(object.LastModified.getTime() / 1000) : undefined
+              const lastModifiedTime = object.LastModified ? Math.floor(object.LastModified.getTime() / 1000) : 0;
+              if(lastModifiedTime <= lastCleanUp) {
+                const headParams: AWS.S3.HeadObjectRequest = {
+                  Bucket: config.s3Bucket as string,
+                  Key: object.Key as string
                 };
+                
+                const metadata = await s3.headObject(headParams).promise();
+                const cid = metadata.Metadata?.['cid'] || metadata.Metadata?.['x-amz-meta-cid'];
+                
+                if (cid) {
+                  yield {
+                    cid,
+                    key: object.Key,
+                    createdAt: object.LastModified ? lastModifiedTime : undefined
+                  };
+                }
               }
             } catch (err) {
               logError(`Failed to get metadata for object: ${object.Key}`, err);
@@ -128,8 +128,7 @@ export class PinningService implements PersistenceService {
     }
   }
 
-  // @todo update input
-  async unpinAll(pins: {cid: string, key: string, createdAt?: number}[]): Promise<number> {
+  async unpinAll(pins: Pin[]): Promise<number> {
     try {
       let unpinnedCounter = 0;
       const s3 = new AWS.S3({
@@ -142,9 +141,9 @@ export class PinningService implements PersistenceService {
 
       // Delete objects one by one
       for (const pin of pins) {
-        const deleteParams = {
+        const deleteParams: AWS.S3.Types.DeleteObjectRequest = {
           Bucket: config.s3Bucket as string,
-          Key: pin.key
+          Key: pin.key as string
         };
         
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,11 @@ export interface Profile {
 }
 
 export type CompleteProfile = Profile & IPFSDataProfile;
+
+export type Pin = {
+  cid: string;
+  type?: string;
+  key?: string; // filebase (S3 key)
+  createdAt?: number; // UNIX time of the record creation
+}
+

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -39,7 +39,7 @@ export class CacheService<T> {
         this.cache.set(key, value);
     }
 
-    public delete(key: string): void {
-        this.cache.delete(key);
+    public delete(key: string): boolean {
+        return this.cache.delete(key);
     }
 }


### PR DESCRIPTION
- [x] A cleanup job runs at a configurable interval.
  - [x] only one cleanup job can run at the same time
  - [x] profiles that are younger than the last clean-up run must be left untouched
*Implemented only for filebase, as with the regular ipfs instance we have no obvious way to extract the creation time*
  - [x] the ipfs pin are removed
  - [ ] deletion of all index rows that should be cleaned-up is executed in one transaction
*not relevant anymore, as the task is old*

The following env params were introduced:
```
CLEANUP_BATCH_SIZE=
CLEANUP_INTERVAL= // in mins
CLEANUP_ENABLED= // boolean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated cleanup operations with configurable scheduling options, allowing for efficient batch processing of outdated resources.
  - Enhanced resource management with improved bulk deletion and streaming capabilities for faster processing.
  - Added a new method for checking the existence of multiple content identifiers in the profiles database.

- **Chores**
  - Updated project dependencies to bolster scheduling support and type safety.
  - Refined caching functionality to provide immediate feedback on deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->